### PR TITLE
Update to patch 18.40371 / build 564659

### DIFF
--- a/parser/consts.go
+++ b/parser/consts.go
@@ -5,7 +5,7 @@ const DATA_OFFSET = 6
 const ROOT_NODE_TOKEN = "BG"
 const VERSION = "v0.3.1"
 
-var FOOTER = []uint8{0, 1, 0, 0, 0, 0, 0, 0}
+var FOOTER = []uint8{0x19, 0x0, 0x0, 0x0}
 
 var NODES_WITH_SUBSTRUCTURE = map[string]struct{}{
 	"BG": {},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -86,10 +86,14 @@ func Parse(replayPath string, slim bool, stats bool, isGzip bool) (ReplayFormatt
 	// 	fmt.Println(child)
 	// }
 
+	commandCount := readUint32(&raw_data, 23)
+	slog.Debug("commandCount", "commandCount", commandCount)
+
 	svBytes := bytes.Index(raw_data, []byte{0x73, 0x76}) // search for index of the "sv" bytes
 	commandOffset := readUint32(&raw_data, svBytes+2)
 	slog.Debug("commandOffset", "commandOffset", commandOffset)
-	commandList, err := parseGameCommands(&raw_data, int(commandOffset))
+
+	commandList, err := parseGameCommands(&raw_data, int(commandOffset), int(commandCount))
 	if err != nil {
 		return ReplayFormatted{}, err
 	}

--- a/parser/types.go
+++ b/parser/types.go
@@ -103,10 +103,9 @@ func (node NotRootNodeError) Error() string {
 }
 
 type CommandList struct {
-	entryIdx     int
-	offsetEnd    int
-	finalCommand bool
-	commands     []RawGameCommand
+	entryIdx  int
+	offsetEnd int
+	commands  []RawGameCommand
 }
 
 type FooterNotFoundError int
@@ -115,10 +114,10 @@ func (err FooterNotFoundError) Error() string {
 	return fmt.Sprintf("Footer not found searching at offset=%v", int(err))
 }
 
-type UnkNotEqualTo1Error int
+type UnkNotExpectedValueError int
 
-func (err UnkNotEqualTo1Error) Error() string {
-	return fmt.Sprintf("The unknown byte in footer search did not equal 1 at offset %v", strconv.FormatInt(int64(err), 16))
+func (err UnkNotExpectedValueError) Error() string {
+	return fmt.Sprintf("The unknown byte in footer search did not equal 0 or 1 at offset %v", strconv.FormatInt(int64(err), 16))
 }
 
 // ===============================


### PR DESCRIPTION
This fixes parsing of the latest (current patch). Some replays I used to test:
[replays.zip](https://github.com/user-attachments/files/21548423/replays.zip)

A notable change is that command parsing was reworked. 

Previously, you were detecting the first command list's footer, then skipping to the second command, and starting the parsing from there. This leaves behind one command list and also forces you to terminate on resign command, which is not ideal.

The new approach is to find the first command list footer, go back to the command list start, and parse from there. This means all command lists are parsed, and we can use the command list count from the replay itself to know how much to go.

As a side effect, I tested parsing a team game and it parsed correctly? It's included in the ZIP.