### PR TITLE
Fix misrecognition of node

### DIFF
--- a/parser/header.go
+++ b/parser/header.go
@@ -50,11 +50,14 @@ func parseTree(data *[]byte, parentNode *Node) {
 			break
 		}
 
-		position = nextNodeLoc
-		childNode := newNode(data, position)
+		childNode := newNode(data, nextNodeLoc)
 		childNode.parent = parentNode
-		parentNode.children = append(parentNode.children, &childNode)
-		position = childNode.endOffset()
+		if childNode.endOffset() > parentNode.endOffset() || childNode.path() == "BG/GM/GD/uI" {
+			position = nextNodeLoc + 1
+		} else {
+			parentNode.children = append(parentNode.children, &childNode)
+			position = childNode.endOffset()
+		}
 	}
 
 	for _, child := range parentNode.children {


### PR DESCRIPTION
In the latest patch, there's a sequence of letters "uI" which gets incorrectly recognized as a node, and this ends up skipping over the real "gd" node right after it, which is our XMB map. Ideally we would properly parse the nodes, but since that's a huge undertaking, we just "blocklist" this instance for now.

This fixes parsing replays on the latest patch.

Example replay:
[2025-08-08-21963147-rm_alfheim-amphibiansurfer_pos-bontafmp_fux.mythrec.zip](https://github.com/user-attachments/files/21689740/2025-08-08-21963147-rm_alfheim-amphibiansurfer_pos-bontafmp_fux.mythrec.zip)
