### PR TITLE
Parse replays from build 601511 + add CLAUDE.md onboarding

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; case \"$f\" in *.go) gofmt -w \"$f\";; esac; } 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+Onboarding notes for Claude / AI agents and human contributors working in this repo. Keep it tight; update when something here goes stale.
+
+## What this is
+
+`restoration` is a CLI that parses Age of Mythology: Retold replay files (`.mythrec`, optionally gzipped as `.mythrec.gz`) into JSON. The replay file is a binary format produced by the game itself; this tool decompresses it, walks its node tree, and decodes the player command log so the data can be inspected, archived, or fed into stats services like aomstats.io.
+
+The format is **not officially documented**. Knowledge of it is reverse-engineered, partly inherited from prior community work (notably loggy's Python proof-of-concept and the next-aom-gg TS parser — see README). This repo does **not** claim to understand every byte of a replay or every command type; see "Known unknowns" below.
+
+## Layout
+
+```
+main.go                 # thin entry: cmd.Execute()
+cmd/                    # Cobra CLI (root, parse, rename, version)
+parser/                 # all replay-decoding logic — see parser/CLAUDE.md
+bin/build.sh            # cross-compile for linux/darwin/windows
+.github/workflows/      # release workflow, triggers on `v*` tag push
+releases/               # build output (gitignored)
+```
+
+The CLI is intentionally thin — `cmd/parse.go` validates the path and calls `parser.ParseToJson`. Almost all complexity lives in `parser/`.
+
+## Subcommands
+
+| Command   | What it does                                                |
+| --------- | ----------------------------------------------------------- |
+| `parse`   | Parse a single replay file → JSON to stdout or `-o` path    |
+| `rename`  | Walk a directory and rename replays based on parsed players |
+| `version` | Print parser version (sourced from `parser.VERSION`)        |
+
+Global flags: `--is-gzip` (file is gzipped), `-v/--verbose` (debug logging).
+`parse` flags: `-o/--output`, `-q/--quiet`, `--pretty-print`, `--slim` (drop game commands), `--stats` (per-player aggregates; mutually exclusive with `--slim`).
+
+The contract for `parse`: **stdout is pure JSON.** All logging goes through `log/slog` to stderr so `restoration parse … | jq …` always works. Don't break this — no `fmt.Println` for diagnostics.
+
+## Build, run, format
+
+```bash
+go build -o restoration                  # local dev binary
+go run . parse path/to/file.mythrec.gz --is-gzip --slim --pretty-print
+bin/build.sh                              # cross-compile all release targets to releases/
+go fmt ./...                              # required before commits
+go vet ./...                              # recommended sanity check
+```
+
+There is no test suite yet (see "Known unknowns"). The release workflow (`.github/workflows/release.yaml`) runs on `v*` tag pushes, builds for linux-amd64 / darwin-amd64 / darwin-arm64 / windows-amd64, and attaches binaries to a GitHub Release.
+
+When bumping the parser version, update `parser/consts.go` (`VERSION`) and tag the commit `vX.Y.Z` to trigger the release.
+
+## Dependencies
+
+- Go 1.23.4
+- `github.com/spf13/cobra` — CLI framework
+
+That's the entire external surface. Stdlib handles compression (`compress/gzip`, `compress/zlib`), encoding (`encoding/binary`, `encoding/json`), UTF-16, etc. Keep the dependency footprint small.
+
+## Conventions
+
+- `go fmt` is canonical — tabs, idiomatic Go.
+- Use `log/slog` for all logging. Be liberal with `slog.Debug`. Never `fmt.Println` for diagnostics — it leaks into the JSON stream.
+- Naming convention in `parser/`: a `parse*` function operates on the raw `[]byte` slice; everything else operates on already-decoded structs. Preserve this split when adding code.
+- Errors propagate up to the CLI layer, which prints to stderr and exits non-zero. Don't `os.Exit` from inside the parser.
+- Conventional commits in commit messages (e.g. `fix:`, `feat:`, `chore:`).
+
+## Known unknowns (read this before changing the parser)
+
+The replay format is reverse-engineered. Several things are explicitly unfinished:
+
+- **Not all game commands are decoded.** Commands 18, 39, 55, 73, 78 are recognized (their byte length is known well enough to advance the cursor) but their payloads are not extracted. Many other command IDs may exist in the wild and will cause the parser to **fail hard** — see `parser/gameCommandParser.go` where an unregistered command type returns an error with no fallback.
+- **Discovering a new command is empirical.** The workflow is: launch the game, perform the action you want to identify, save the replay, diff it against a baseline replay, and locate the new bytes. Hardcoded byte offsets and length heuristics in `parser/gameCommands.go` are the result of this process. Patches to the game can shift these.
+- **Team game support is partial.** Winner detection assumes 1v1 (`Winner = !losingTeam`). FFA and team games are not fully validated.
+- **No automated tests.** No fixture replays are checked in. Verify changes by parsing real replay files locally and inspecting the JSON diff.
+- **Some header/XMB structure is still mysterious.** See TODOs in `parser/header.go` (e.g. the `kL` node) and `parser/gameCommands.go` (cheat name lookup, command 78 length heuristic).
+
+When AoM ships a patch, the parser may break. Recent commit history is dominated by post-patch fixes (commands 73/78, AI player parsing, node misrecognition). Treat the parser as a living artifact that tracks the live game.
+
+## Verifying a change
+
+There is no `go test ./...` to lean on. After touching `parser/`:
+
+1. Parse a known-good replay with `--pretty-print` and compare the JSON to a saved baseline.
+2. If the change touches game commands, parse with `--stats` too and sanity-check counts (units trained, techs researched, EAPM) against expectations from the actual game.
+3. If a player has reported a broken replay, parse that file specifically and confirm it now succeeds.
+4. `go vet ./...` and `go fmt ./...` before committing.
+
+## Debugging a new-patch parsing failure
+
+When AoM ships a patch and replays from the new build start failing, the workflow that has worked well is:
+
+### Ask up front for the right inputs
+
+Before digging in, ask the user (or yourself) for:
+
+- **One known-good replay from the previous patch** — this is the single most valuable artifact. It anchors "what the format used to look like" so you can diff against it byte-for-byte. Without it, you're reverse-engineering in the dark.
+- **More than one failing replay from the new patch.** Different games surface different bugs:
+  - A short / fast-resign game has very few commands and may parse "successfully" while masking deeper issues (a 2-second resign in this codebase hit only `autoqueue` + `resign`, hiding a `prequeueTech` byte-length change that broke longer games).
+  - A full multi-age game with research, prequeue, god powers, builds, trains gives broad coverage of command-type code paths.
+  - Two new replays let you confirm a structural change is reproducible (same `mU` offset preamble, same byte sentinels) rather than file-specific noise.
+
+Surface this to the user proactively: "Got the failing replay — do you also have one from the previous patch that *did* work, and ideally a longer non-resign new replay too? Comparing them is much faster than working from the failing file alone."
+
+### The diagnostic ladder
+
+Run these in order; each rules out a layer of the format:
+
+1. **Reproduce the error and read it literally.** The parser surfaces structural violations (`x1 not equal to 12632`, `entryIdx was not sequential`, `refiner not defined for commandType=N`) — those are precise pointers to *where* in the format the assumption broke. Don't paper over them.
+2. **Check the file is what you think it is.** `file <path>` and `xxd | head` confirm gzip vs raw vs new wrapper. Magic bytes: `1f 8b` = gzip, `6c 33 33 74` = `l33t`, the `RG` outer wrapper has lived inside replays for a while now.
+3. **Decompress to inner bytes once.** Save them under `/tmp/inner_<TAG>.bin` for the failing file *and* the known-good one. All subsequent analysis uses these.
+4. **Diff outer headers and BG roots.** If they're byte-identical for the first ~256 bytes, layout changes are deeper than the wrapper — go to step 5. If they differ, your bug is structural in the wrapper.
+5. **Walk the header tree (Python, mirroring `parser/header.go` `parseTree`/`findTwoLetterSeq`).** Print children of `BG/GM/GD`, `BG/MP/ST`, `BG/J1/PL`. Histogram the child tokens. A new token (in this session: `mU`) appearing only in the new file is a strong lead.
+6. **Diff XMB name lists.** Iterate `BG/GM/GD/gd` children, registering single-file and multi-file entries the same way `parseXmbMap` does. Compare old vs new sets — this is how we found `proto` had been removed.
+7. **Search for known strings as UTF-16 LE in the new inner data.** If a unit/tech/god name from the old format still exists in the new file, you can locate where it was moved to (and check whether it's still XMB-shaped at that location).
+8. **For command-stream desyncs, instrument and bisect.** Add a temporary `slog.Debug` of `commandType` and `offset` at the top of `parseGameCommand`, run with `-v`, capture stdout. Look for the last successful command before the failing iteration; dump raw bytes from that command's offset against the same command in the old file. The byte position where they diverge is your fix.
+9. **Prefer probe-and-detect over hard-coding patches.** Where possible, fix by detecting the format dynamically (e.g., the `prequeueTech` 13-vs-16-byte fix probes for the `00 01 19` footer envelope at both candidate positions instead of switching on build number). Self-detecting code keeps OLD replays working without threading build numbers through the parser. Only fall back to a build-number switch if no reliable signal is available.
+10. **Verify on every replay you have, including OLD.** Diff the OLD JSON output before and after the fix — it must be unchanged. Then check the new replays produce the human-meaningful fields the user cares about (map, players, gods, minor gods).
+
+### Things to remember about this codebase
+
+- `parseXmb` is **structure-driven**, not size-bounded. It will happily read past a containing node's reported size if the XMB internally claims more children. This is a feature, not a bug — it's how the new `mU` proto catalog (which spills past `mU.size` into bytes the header walk treats as sibling `XN` nodes) gets parsed correctly.
+- `findTwoLetterSeq` scans up to 50 bytes for the next valid ASCII pair, so non-ASCII padding inserted between header nodes is naturally tolerated.
+- `Decompressl33t` finds the `l33t` magic via `bytes.Index`, so any leading wrapper bytes are silently skipped.
+- The `kL` token is explicitly skipped during header parsing (`header.go`); add similar skips for any new bogus token if needed.
+- A graceful-fallback helper (`parseXmbIfPresent` in `formatter.go`, `protoName` in `gameCommands.go`) is the standard pattern for "XMB might be missing/renamed" — keep using it for new lookups.
+
+## Pointers to deeper docs
+
+- `parser/CLAUDE.md` — internals of the parser package: format anatomy, file roles, decoding pipeline, gotchas.
+- `README.md` — user-facing docs and example output. Update this when changing CLI flags or output shape.

--- a/parser/CLAUDE.md
+++ b/parser/CLAUDE.md
@@ -1,0 +1,180 @@
+# parser/CLAUDE.md
+
+Internals of the `parser` package. The root `CLAUDE.md` covers project-level context — start there if you haven't.
+
+## What this package does
+
+Takes a `.mythrec` file path, decompresses it, walks its binary node tree, parses the embedded XMB metadata files and the player command log, and returns a JSON-serializable `ReplayFormatted` struct. Nothing in here is concurrency-safe; nothing in here knows about flags or the CLI.
+
+## Public API
+
+```go
+parser.ParseToJson(replayPath string, prettyPrint, slim, stats, isGzip bool) (string, error)
+parser.Parse(replayPath string, slim, stats, isGzip bool) (ReplayFormatted, error)
+parser.RenameRecFiles(dir string, isGzip bool, prefix, suffix string) error
+parser.VERSION  // const, kept in consts.go
+```
+
+`ParseToJson` is `Parse` + `json.Marshal`. The CLI calls `ParseToJson`; programmatic consumers can call `Parse` directly to skip the JSON round-trip.
+
+## File roles
+
+| File                    | Responsibility                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `parser.go`             | Top-level orchestration: `Parse`, `ParseToJson`, profile-key reader                               |
+| `decoder.go`            | Low-level binary primitives: int/float/bool/vector/string readers, gzip + l33t decompression      |
+| `header.go`             | Parses the recursive node tree at the front of the file (the "header")                            |
+| `xmb.go`                | Parses XMB (binary XML) blobs embedded in the header                                              |
+| `gameCommandParser.go`  | Walks the command-log section, splits it into per-tick batches, dispatches to refiners            |
+| `gameCommands.go`       | One refiner per known command type — produces typed `RawGameCommand` values                       |
+| `formatter.go`          | Lazy-decodes XMB lookup tables and turns raw structs into the human-readable `ReplayFormatted`    |
+| `stats.go`              | Per-player aggregates (unit counts, EAPM timeline, etc.) when `--stats` is on                     |
+| `renamer.go`            | Implements `restoration rename`: walks a dir, parses each replay, renames using player names      |
+| `types.go`              | All shared structs: `ReplayFormatted`, `ReplayPlayer`, `ReplayGameCommand`, `Node`, `XmbNode`, …  |
+| `consts.go`             | Magic constants: `VERSION`, footer bytes, root-node token, set of nodes with substructure         |
+
+Convention: `parse*` functions operate on raw `[]byte`. Everything else operates on already-decoded structs. Preserve this split.
+
+## Replay file anatomy
+
+```
+[ optional gzip ]
+  └─ [ l33t-compressed (zlib) blob ]
+       ├─ Header
+       │     Recursive tree of nodes. Each node = 2-byte ASCII token + uint32 length + payload.
+       │     Nodes in NODES_WITH_SUBSTRUCTURE ({BG, J1, PL, BP, MP, GM, GD}) contain children;
+       │     others are leaves. Profile keys (player names, map, seed, game options) live here.
+       │     Root token is "BG".
+       ├─ XMB blocks
+       │     Embedded under GM/GD nodes. Binary XML files: civs, techtree, proto, powers, etc.
+       │     They're the lookup tables that map numeric IDs in commands → human-readable names.
+       │     Their offsets are mapped up front; their contents are parsed lazily in formatter.go.
+       └─ Command log
+             A sequence of per-tick batches (game runs at 20 Hz, so 1 batch = 0.05 s).
+             Each batch contains 0..N commands. Each command has a type byte, player id,
+             selected units, source vectors, and a type-specific payload.
+             FOOTER bytes (0x19 00 00 00) demarcate batch boundaries.
+```
+
+All multi-byte integers are little-endian. Strings are UTF-16 LE prefixed by a uint16 char count and 2 bytes of padding (see `readString` in `decoder.go`).
+
+## Pipeline
+
+```
+Parse
+ ├─ os.ReadFile
+ ├─ DecompressGzip      (if --is-gzip)
+ ├─ Decompressl33t      (always; the inner zlib layer)
+ ├─ parseHeader         → Node tree
+ ├─ parseXmbMap         → map[string]XmbFile (offsets only, not parsed)
+ ├─ parseProfileKeys    → game metadata (players, map, options, seed)
+ ├─ parseGameCommands   → []CommandList (raw, typed game commands)
+ └─ formatRawDataToReplay
+      ├─ lazy parseXmb on civs / techtree / proto / powers
+      ├─ build ReplayPlayers (god, color, minor gods, EAPM, winner)
+      ├─ stringify each command via XMB lookups → []ReplayGameCommand
+      └─ if stats: calcStats → per-player aggregates and per-minute timelines
+```
+
+The XMB tables are large; `formatRawDataToReplay` parses them once and shares them across all command-formatting calls. Don't move XMB parsing back into `parseHeader` — it materially slows batch processing.
+
+## Game commands
+
+Each command type has an entry in the factory built by `BuildCommandFactory()` in `gameCommands.go`. An entry is `{ Name, Refine }`:
+
+- `Refine` reads command-specific bytes after a fixed header and returns a typed `RawGameCommand` (e.g. `TaskCommand`, `ResearchCommand`, `BuildCommand`).
+- The typed command implements `Format(FormatterInput) (ReplayGameCommand, bool)` to produce the user-facing form (with IDs resolved to names via XMB).
+- The `affectsEAPM` flag on `BaseCommand` decides whether the command is counted toward player EAPM. Some "spammy" commands (gather points, auto-scout, control groups, wall connectors, transform starts) are intentionally excluded.
+
+### Currently registered command types
+
+See the table at `gameCommands.go` `BuildCommandFactory()` for the authoritative list. Roughly: 0 task, 1 research, 2 train, 3 build, 4 setGatherPoint, 7 delete, 9 stop, 12 useProtoPower, 13 marketBuySell, 14 ungarrison, 16 resign, 19 tribute, 23 finishUnitTransform, 25 setUnitStance, 26 changeDiplomacy, 34 townBell, 35 autoScoutEvent, 37 changeControlGroup, 38 repair, 41 taunt, 44 cheat, 45 cancelQueuedItem, 48 setFormation, 53 startUnitTransform, 66 autoqueue, 67 toggleAutoUnitAbility, 68 timeShift, 69 buildWallConnector, 71 seekShelter, 72 prequeueTech, 75 prebuyGodPower. Plus opaque-payload entries: 18, 39, 55, 73, 78.
+
+### Adding or fixing a command type
+
+There are no test fixtures. The empirical loop:
+
+1. Reproduce the action in-game and save the replay.
+2. Parse with `-v` (verbose). If the parser errors with `"refiner not defined for commandType=N"`, you've found a new ID.
+3. Diff bytes around that command against a known one of similar shape.
+4. Add a `Refine` function and a factory entry. If you don't yet understand the payload, register it as an opaque `UnknownN` (consume bytes, don't extract semantics — see existing `Unknown18`/`Unknown39`/`Unknown55`/`Unknown73`/`Unknown78` for the pattern).
+5. Re-parse other replays to confirm you haven't broken anything.
+
+When a refiner advances the cursor by a constant (e.g. `offset += 20`), comment why if it's at all unobvious. Several of these are already mysterious; don't make it worse.
+
+### Fragile spots to know about
+
+- `Unknown78` reads a byte at `offset+12` to decide between 20 and 24-byte length — pure heuristic.
+- Formation IDs are hardcoded `0=line, 1=box, 2=spread`; anything else logs a warning and becomes `"unknown"`.
+- Resource IDs only recognize 1=wood, 2=food. Gold / favor / etc. fall through to `"unknown"` — likely incomplete.
+- `cheatCommand` stores the cheat ID but does not yet resolve the name (TODO in `gameCommands.go`).
+- `header.go` has a `kL` node it explicitly skips with a TODO. Purpose unknown.
+- Winner detection assumes 1v1: `Winner = !losingTeams[teamId]`. Team-game correctness is best-effort.
+
+## Things that will break the parser hard
+
+- A new game command ID in the wild that isn't registered → returns an error with no recovery.
+- An XMB file with an unexpected magic / version → the strict checks in `xmb.go` panic the parser.
+- An AoM patch that shifts byte offsets in command payloads → silent wrong values until someone notices.
+
+When debugging a "this replay won't parse" report, run with `-v`, find the first failure offset, and bisect against a working replay from a similar game mode and patch version.
+
+## Patch-debugging playbook (worked example: build 601511, May 2026)
+
+The root `CLAUDE.md` has the general workflow. This section is the codebase-specific patterns that came out of fixing build 601511, where two simultaneous breakages were hidden behind a single error message.
+
+### What changed and where
+
+| Change | Old (≤600762) | New (≥601511) | Where in the parser |
+| ------ | ------------- | ------------- | ------------------- |
+| Unit catalog location | `BG/GM/GD/gd` named `proto` | `BG/GM/GD/mU` with 14-byte preamble (`00 00 01 67 64 3d 78 58 00 00 01 00 00 00`), then standard X1 XMB | `xmb.go::parseXmbMap` registers `mU.offset + DATA_OFFSET + 14` as `xmbMap["proto"]` |
+| `prequeueTech` byte length | 13 bytes (8 sentinel + 4 techId + 1 flag) | 16 bytes (8 sentinel + 4 techId + 4-byte field) | `gameCommands.go::PrequeueTechCommand.Refine` probes for the post-command `00 01 19` footer envelope at +13 and +16, picks the matching length |
+
+These were both real and load-bearing for the user's stated goal (minor gods on a real game). The unit-catalog fix alone only got short / instant-resign replays working; the prequeueTech length fix was needed for any game with age-up prequeues — which is most non-trivial games.
+
+### Why two replays mattered
+
+- The first failing replay was a 2-second resign. With `proto` gone, parsing crashed on XMB magic. After fixing that, the file parsed cleanly: 2 commands, no minor gods (player resigned in age 1).
+- A second failing replay (long, multi-age) was needed to expose the prequeueTech byte-length change. The first replay had no `prequeueTech` commands at all, so the bug was invisible.
+- Always ask for both a long new replay *and* a known-good old replay before declaring "this format hasn't changed in <area>." Confidence comes from cross-replay consistency.
+
+### Debug techniques that paid off
+
+1. **Decompress once to `/tmp/inner_*.bin`, work in Python.** Reproducing `parseTree` / `parseXmbMap` / `parseXmb` in ~30 lines of Python lets you iterate on hypotheses in seconds without rebuilding Go. The Python parser doesn't need to be production-quality — it's a probe.
+2. **Histogram the children of `BG/GM/GD`.** OLD had `gd: 67`. NEW had `gd: 66, XN: 382, mU: 1`. The new `mU` token plus the disappearance of one `gd` was the entire structural diff.
+3. **Set-diff the XMB name lists.** Computing `OLD_names \ NEW_names` (and the reverse) immediately surfaced "exactly `proto` was removed" — no other XMB renames or additions.
+4. **Search inner bytes for known UTF-16 strings.** `VillagerGreek`/`Hoplite`/`TownCenter` showed up dozens of times in the new file, proving the catalog hadn't moved out of the replay — it had relocated. Then matching positions to header-tree node ranges pinpointed `mU` as the new home.
+5. **For desyncs, instrument `parseGameCommand` with `slog.Debug("commandType", commandType, "offset", offset)` and run `-v`.** Histogram the resulting log to learn which command types ran successfully and which one is sitting on the boundary at the failure. In our case the log said: 86 task, 32 autoScout, … 1 prequeueTech (the failing one). That immediately scoped the fix to one command type.
+6. **Probe-and-detect beats hard-coded version checks** when the format change has a reliable byte-level signature. The `prequeueTech` fix detects the new layout by probing for the universal command-list footer envelope `00 01 19` at the two candidate offsets — works on both old and new replays without threading the build number through every refiner.
+7. **`parseXmb` reads through node boundaries.** Don't trust `mU.size`; the proto XMB physically extends past it. The header walk reports 382 spurious `XN` siblings of `mU` — those are just the tail of the proto XMB. As long as `parseXmb` is anchored at `mU.offset + 20`, it reads them correctly.
+
+### Verification recipe used here
+
+```bash
+# the three-replay matrix
+go run . parse ~/Downloads/<NEW1>.mythrec --slim --pretty-print  # short fast-resign
+go run . parse ~/Downloads/<NEW2>.mythrec --pretty-print          # long multi-age
+go run . parse ~/Downloads/<OLD>.mythrec  --pretty-print          # last patch, must be unchanged
+
+# OLD must be byte-identical to its pre-fix output (modulo timestamp)
+diff <(jq -S 'del(.ParsedAt)' /tmp/old_pre.json) <(jq -S 'del(.ParsedAt)' /tmp/old_post.json)
+```
+
+The user-facing pass criteria for any patch fix: map name, player names, gods, **minor gods**, and a non-zero command count with no `"unknown"` payloads on a long game. Minor gods are the canary — they require both `techtree` XMB lookups *and* successful command-stream parsing through age-up prequeues, so when minor gods are right, you've usually got the rest right too.
+
+## Adding stats
+
+`stats.go` builds `ReplayStats` per player from the formatted command list. It buckets timelines into 1-minute slots via `math.Ceil(gameTimeSecs/60)`. To add a new aggregate:
+
+1. Add the field to `ReplayStats` (or `Timelines`) in `types.go`.
+2. Populate it in `calcStats` / `calcTotals` / `calcTimelines`.
+3. Verify via `restoration parse … --stats --pretty-print` against a known replay.
+
+Keep stats deterministic — same replay must produce byte-identical JSON across runs.
+
+## Don'ts
+
+- Don't `fmt.Println` from anywhere in `parser/` — it pollutes stdout, breaking `parse | jq`. Use `slog`.
+- Don't `os.Exit` from inside the parser. Return errors.
+- Don't add concurrency to `Parse` itself without a measured reason; the caller (e.g. `RenameRecFiles`) parallelizes across files instead.
+- Don't introduce dependencies for things `encoding/binary`, `compress/*`, `unicode/utf16` already cover.

--- a/parser/formatter.go
+++ b/parser/formatter.go
@@ -26,13 +26,13 @@ func formatRawDataToReplay(
 	slog.Debug(buildString)
 	buildNumber := getBuildNumber(buildString)
 
-	godsRootNode, err := parseXmb(data, (*xmbMap)["civs"])
+	godsRootNode, err := parseXmbIfPresent(data, xmbMap, "civs")
 	if err != nil {
 		return ReplayFormatted{}, err
 	}
 	majorGodMap := buildGodMap(&godsRootNode)
 
-	techTreeRootNode, err := parseXmb(data, (*xmbMap)["techtree"])
+	techTreeRootNode, err := parseXmbIfPresent(data, xmbMap, "techtree")
 	if err != nil {
 		return ReplayFormatted{}, err
 	}
@@ -61,11 +61,11 @@ func formatRawDataToReplay(
 
 	gameOptions := getGameOptions(profileKeys)
 	var gameCommands []ReplayGameCommand
-	protoRootNode, err := parseXmb(data, (*xmbMap)["proto"])
+	protoRootNode, err := parseXmbIfPresent(data, xmbMap, "proto")
 	if err != nil {
 		return ReplayFormatted{}, err
 	}
-	powersRootNode, err := parseXmb(data, (*xmbMap)["powers"])
+	powersRootNode, err := parseXmbIfPresent(data, xmbMap, "powers")
 	if err != nil {
 		return ReplayFormatted{}, err
 	}
@@ -404,4 +404,17 @@ func addTechsToPlayers(players *[]ReplayPlayer, gameCommands *[]ReplayGameComman
 			}
 		}
 	}
+}
+
+// parseXmbIfPresent looks up an XMB by name and parses it if it exists in the
+// replay. Game patches occasionally remove or rename embedded XMB files; rather
+// than fail the whole parse, missing entries log a warning and return a zero
+// XmbNode so downstream lookups can degrade to "unknown" instead of panicking.
+func parseXmbIfPresent(data *[]byte, xmbMap *map[string]XmbFile, name string) (XmbNode, error) {
+	f, ok := (*xmbMap)[name]
+	if !ok {
+		slog.Warn("XMB not present in replay; downstream lookups will return 'unknown'", "name", name)
+		return XmbNode{}, nil
+	}
+	return parseXmb(data, f)
 }

--- a/parser/gameCommands.go
+++ b/parser/gameCommands.go
@@ -113,6 +113,16 @@ type FormatterInput struct {
 	powersRootNode   *XmbNode
 }
 
+// protoName resolves a unit/building proto id to its human-readable name. The
+// proto XMB was removed from replays in build 601511; when the catalog isn't
+// present, node.children is nil and we return "unknown" rather than panicking.
+func protoName(node *XmbNode, id int32) string {
+	if node == nil || int(id) < 0 || int(id) >= len(node.children) {
+		return "unknown"
+	}
+	return node.children[id].attributes["name"]
+}
+
 type RawGameCommand interface {
 	CommandType() int
 	OffsetEnd() int
@@ -262,7 +272,7 @@ func (cmd TrainCommand) Refine(baseCommand *BaseCommand, data *[]byte) RawGameCo
 }
 
 func (cmd TrainCommand) Format(input FormatterInput) (ReplayGameCommand, bool) {
-	proto := input.protoRootNode.children[cmd.protoUnitId].attributes["name"]
+	proto := protoName(input.protoRootNode, cmd.protoUnitId)
 	return ReplayGameCommand{
 		GameTimeSecs: cmd.GameTimeSecs(),
 		PlayerNum:    cmd.PlayerId(),
@@ -307,7 +317,7 @@ type BuildCommandPaylod struct {
 }
 
 func (cmd BuildCommand) Format(input FormatterInput) (ReplayGameCommand, bool) {
-	proto := input.protoRootNode.children[cmd.protoBuildingId].attributes["name"]
+	proto := protoName(input.protoRootNode, cmd.protoBuildingId)
 	return ReplayGameCommand{
 		GameTimeSecs: cmd.GameTimeSecs(),
 		PlayerNum:    cmd.PlayerId(),
@@ -930,7 +940,7 @@ func (cmd AutoqueueCommand) Refine(baseCommand *BaseCommand, data *[]byte) RawGa
 }
 
 func (cmd AutoqueueCommand) Format(input FormatterInput) (ReplayGameCommand, bool) {
-	proto := input.protoRootNode.children[cmd.protoUnitId].attributes["name"]
+	proto := protoName(input.protoRootNode, cmd.protoUnitId)
 	return ReplayGameCommand{
 		GameTimeSecs: cmd.GameTimeSecs(),
 		PlayerNum:    cmd.PlayerId(),
@@ -1035,10 +1045,23 @@ type PrequeueTechCommand struct {
 }
 
 func (cmd PrequeueTechCommand) Refine(baseCommand *BaseCommand, data *[]byte) RawGameCommand {
-	// The prequeTech command is 13 bytes in length, bytes 8-12 are an int32 representing the id of the tech
-	// that was prequeued. The id maps to a string via the techtree XMB data stored in the header of the replay.
-	// inputTypes := []func() int{unpackInt32, unpackInt32, unpackInt32, unpackInt8}
+	// The prequeueTech command body always starts with 8 bytes of 0xff (a sentinel
+	// for "no source"), then 4 bytes of techId. After that:
+	//   - build < 601511: 1 trailing flag byte → byteLength = 13
+	//   - build ≥ 601511: 4 trailing bytes (a new field replacing the flag) → byteLength = 16
+	// The patch didn't touch other commands' byte layouts, so we don't thread a
+	// build number through the parser; instead we probe for the next command-list
+	// footer envelope (`00 01 0x19`) at the two candidate positions and pick the
+	// matching length.
+	derefedData := *data
+	o := baseCommand.offset
 	byteLength := 13
+	matchesAt := func(end int) bool {
+		return derefedData[o+end] == 0x00 && derefedData[o+end+1] == 0x01 && derefedData[o+end+2] == 0x19
+	}
+	if !matchesAt(13) && matchesAt(16) {
+		byteLength = 16
+	}
 	enrichBaseCommand(baseCommand, byteLength)
 	techId := readInt32(data, baseCommand.offset+8)
 	return PrequeueTechCommand{

--- a/parser/xmb.go
+++ b/parser/xmb.go
@@ -42,6 +42,20 @@ func parseXmbMap(data *[]byte, rootNode Node) (map[string]XmbFile, error) {
 		dataLength := readUint32(data, offset+2)
 		offset += int(dataLength) + DATA_OFFSET
 	}
+
+	// Build 601511 (released 2026-05-02) moved the unit/building catalog out of
+	// a top-level "proto" gd into a sibling node "mU" under BG/GM/GD. The mU
+	// content begins with a 14-byte preamble (00 00 01 'gd' <uint32> 00 00 01
+	// 00 00 00) and then a normal X1 XMB whose root element is "proto". The
+	// XMB extends past mU's reported size into the bytes that the header walk
+	// otherwise mistakes for sibling XN nodes; parseXmb is structure-driven so
+	// it reads through them correctly.
+	for _, mU := range rootNode.getChildren("GM", "GD", "mU") {
+		xmbMap["proto"] = XmbFile{
+			name:   "proto",
+			offset: mU.offset + DATA_OFFSET + 14,
+		}
+	}
 	return xmbMap, nil
 }
 


### PR DESCRIPTION
## Summary

- Fixes parsing of `.mythrec` files from AoMR build 601511 (patch 19.11687, May 2026). The new patch made two simultaneous format changes that were both load-bearing for non-trivial games.
- Adds AI/contributor onboarding docs (`CLAUDE.md`, `parser/CLAUDE.md`) including a patch-debugging playbook.

## Format changes handled

1. **Unit catalog moved.** The `proto` XMB (1754 unit/building entries) was removed from `BG/GM/GD/gd` and relocated into a new `mU` node under `BG/GM/GD` with a 14-byte preamble before the standard X1 XMB. `parseXmbMap` now registers `mU.offset + 20` as `xmbMap[\"proto\"]`. The XMB physically extends past `mU.size`, but `parseXmb` is structure-driven so it reads through correctly.
2. **`prequeueTech` byte length 13 → 16.** The trailing 1-byte flag was replaced by a 4-byte field after `techId`. The refiner probes for the post-command footer envelope `00 01 19` at the two candidate offsets and picks the matching length — old and new replays both parse without threading a build number through the parser.

Also makes the four formatter XMB lookups graceful (`parseXmbIfPresent`) and guards the three proto-id call sites in `Train`/`Build`/`Autoqueue` `Format` methods (`protoName`).

## Verification

| Replay | Build | Map | Players | Gods | Minor gods | Total cmds | Unknown |
| --- | --- | --- | --- | --- | --- | --- | --- |
| oasis (fast resign) | 601511 | oasis ✓ | imlaladrik, Ervaen ✓ | Oranos, Gaia ✓ | (instant resign) | 2 | 0 |
| mirage (full game) | 601511 | mirage ✓ | anbo, matiasenuri ✓ | Susanoo, Zeus ✓ | InariOkami/Raijin/Watatsumi & Hermes/Apollo/Hera ✓ | 522 | 0 |
| cloud_forest (prior patch) | 600762 | cloud_forest ✓ | Ape of Mythology, Aces.HUSKSUPPE ✓ | Oranos, Huitzilopochtli ✓ | Oceanus & Patecatl/Itzpapalotl ✓ | 347 | 0 |

The cloud_forest output is byte-identical to pre-fix (modulo timestamp) — no regression on older replays.

## Test plan

- [x] `go fmt ./...` and `go vet ./...` pass clean
- [x] Parse the new oasis fast-resign replay: exits 0, success-criteria fields correct
- [x] Parse the new mirage full game: exits 0, all minor god ages populated, 0 \"unknown\" payloads across 522 commands of 8 different types
- [x] Parse the prior-patch cloud_forest replay: output byte-identical to current `main` modulo `ParsedAt`
- [x] Confirmed via `-v`: when `proto` is missing from a replay (e.g. an even older format) the new helpers log a warning and degrade to \"unknown\" rather than crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)