### PR TITLE
fix: parse build 601511 prequeueTech mid-list + patch-compat policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,33 @@ The replay format is reverse-engineered. Several things are explicitly unfinishe
 
 When AoM ships a patch, the parser may break. Recent commit history is dominated by post-patch fixes (commands 73/78, AI player parsing, node misrecognition). Treat the parser as a living artifact that tracks the live game.
 
+## Patch compatibility policy
+
+**The parser tracks the current AoM build. It does not try to read replays from older builds.** When a patch changes a byte layout, hardcode the new size and move on — don't probe-and-detect, don't thread build numbers through the refiners, don't accumulate format-version branches.
+
+Why:
+- The replay format is reverse-engineered and brittle. Each compatibility branch is another thing that can be subtly wrong (the May-2026 `prequeueTech` probe matched the trailing footer envelope but quietly defaulted to the old length when prequeueTech sat mid-list — silently wrong for several real games before we noticed).
+- Per-build branches in refiners compound: every future patch widens the matrix. Hardcoding keeps `gameCommands.go` readable.
+- Old replays still exist — but read them with the parser version that was current when the replay was recorded. The release workflow tags every parser version, so the binaries are still on GitHub Releases.
+
+What to do when a patch shifts a byte layout:
+
+1. Confirm the new size (see the playbook below) and update the refiner.
+2. **Annotate the change in the refiner with a dated comment** so future readers can see at a glance which builds the current code targets:
+   ```go
+   // Patch history:
+   //   YYYY-MM-DD: build NNNNNN changed the size from X to Y. <one-line why if known>
+   ```
+   Keep entries in chronological order. A short stack of these is fine; it's a useful record, not clutter.
+3. Bump `parser.VERSION` (`parser/consts.go`) and tag the commit so the release workflow ships a binary that's pinned to "this parser parses replays from build NNNNNN onward."
+4. Mention the build cutover in the PR description so users searching for "won't parse my old replay" can find which release to download.
+
+When *not* to apply this policy:
+- A change that is genuinely build-agnostic (e.g. tolerating a new header token added without removing the old one). If both old and new replays still produce identical output through the new code, no patch-history comment is needed.
+- A bug fix that wasn't actually a format change — fix the bug, no patch-history note.
+
+The user-facing version of this policy lives in `README.md` ("Patch compatibility").
+
 ## Verifying a change
 
 There is no `go test ./...` to lean on. After touching `parser/`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ The format is **not officially documented**. Knowledge of it is reverse-engineer
 main.go                 # thin entry: cmd.Execute()
 cmd/                    # Cobra CLI (root, parse, rename, version)
 parser/                 # all replay-decoding logic — see parser/CLAUDE.md
+tools/                  # ad-hoc Python probes for patch-debugging (uv-runnable) — see tools/CLAUDE.md
 bin/build.sh            # cross-compile for linux/darwin/windows
 .github/workflows/      # release workflow, triggers on `v*` tag push
 releases/               # build output (gitignored)
@@ -153,4 +154,5 @@ Run these in order; each rules out a layer of the format:
 ## Pointers to deeper docs
 
 - `parser/CLAUDE.md` — internals of the parser package: format anatomy, file roles, decoding pipeline, gotchas.
+- `tools/CLAUDE.md` — the ad-hoc Python probes for patch-debugging (command-stream tracer, inner-bytes decompressor); when to reach for them and how they drift from the Go parser.
 - `README.md` — user-facing docs and example output. Update this when changing CLI flags or output shape.

--- a/README.md
+++ b/README.md
@@ -269,3 +269,18 @@ to add coverage for whatever the patch changed.
   - Be liberal with `slog.Debug`
 - Keep the output from the `parse` command clean, it should only be JSON. Ideally one can then take the standard output and pipe it into a file or any other tool (such as `jq`).
   - For example you could get the mapname and winners using this jq string: `jq '{map: .MapName, players: [.Players[] | {name: .Name, winner: .Winner}]}' test.json`
+
+### `tools/` — Python probes for patch-debugging
+
+The [`tools/`](tools/) directory contains ad-hoc Python scripts used when an
+AoM patch breaks parsing: a command-stream tracer that bisects the failure to
+a specific command, and an inner-bytes decompressor for header/XMB diffing.
+They mirror Go-parser logic, are not shipped in the release binary, and have
+[PEP 723](https://peps.python.org/pep-0723/) inline metadata so they run with
+[`uv`](https://docs.astral.sh/uv/) and zero setup:
+
+```bash
+uv run tools/trace_command_stream.py path/to/replay.mythrec
+```
+
+See `tools/CLAUDE.md` for what's there and when to reach for it.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,24 @@ Game commands will be a long list that looks like the following when not in slim
 4. Not all command types are currently paresd and stored in the output JSON, if you have a request for a specific command type please open an issue.
 5. There are currently no stats calculations and a bunch of metadata flags
 
+## Patch compatibility
+
+`restoration` tracks the **current** AoM: Retold build. The replay format is
+reverse-engineered and AoM patches occasionally shift byte layouts inside the
+command log. When that happens we update the parser to match the new build —
+we do not try to read replays from older builds with the same binary.
+
+**To parse an old replay**, download the release of `restoration` that was
+current when the replay was recorded from the
+[Releases page](https://github.com/jerkeeler/restoration/releases). Each
+release pins to the AoM build it was built against; release notes call out
+the cutover. The version emitted in the JSON output (`ParserVersion`) tells
+you which release produced any given parse.
+
+If you have a replay that won't parse and you believe it is from the current
+build, please open an issue and attach the replay — that's the input we need
+to add coverage for whatever the patch changed.
+
 ## Roadmap
 
 - [x] Add support for team games

--- a/parser/consts.go
+++ b/parser/consts.go
@@ -3,7 +3,7 @@ package parser
 const MAX_SCAN_OFFSET = 50
 const DATA_OFFSET = 6
 const ROOT_NODE_TOKEN = "BG"
-const VERSION = "v0.5.2"
+const VERSION = "v0.5.3"
 
 var FOOTER = []uint8{0x19, 0x0, 0x0, 0x0}
 

--- a/parser/gameCommands.go
+++ b/parser/gameCommands.go
@@ -1045,23 +1045,15 @@ type PrequeueTechCommand struct {
 }
 
 func (cmd PrequeueTechCommand) Refine(baseCommand *BaseCommand, data *[]byte) RawGameCommand {
-	// The prequeueTech command body always starts with 8 bytes of 0xff (a sentinel
-	// for "no source"), then 4 bytes of techId. After that:
-	//   - build < 601511: 1 trailing flag byte → byteLength = 13
-	//   - build ≥ 601511: 4 trailing bytes (a new field replacing the flag) → byteLength = 16
-	// The patch didn't touch other commands' byte layouts, so we don't thread a
-	// build number through the parser; instead we probe for the next command-list
-	// footer envelope (`00 01 0x19`) at the two candidate positions and pick the
-	// matching length.
-	derefedData := *data
-	o := baseCommand.offset
-	byteLength := 13
-	matchesAt := func(end int) bool {
-		return derefedData[o+end] == 0x00 && derefedData[o+end+1] == 0x01 && derefedData[o+end+2] == 0x19
-	}
-	if !matchesAt(13) && matchesAt(16) {
-		byteLength = 16
-	}
+	// The prequeueTech command body is 16 bytes: 8 bytes of 0xff (a "no source"
+	// sentinel), 4 bytes of techId, and 4 trailing bytes (purpose unknown).
+	//
+	// Builds before 601511 used a 13-byte body (1 trailing flag byte instead of 4).
+	// We do not support those builds — replays from old patches will misalign here.
+	// The previous probe-and-detect was unreliable for replays that mix prequeueTech
+	// with selected-unit lists or non-trailing positions, and threading a build
+	// number through every command refiner isn't worth the complexity for one field.
+	byteLength := 16
 	enrichBaseCommand(baseCommand, byteLength)
 	techId := readInt32(data, baseCommand.offset+8)
 	return PrequeueTechCommand{

--- a/parser/gameCommands.go
+++ b/parser/gameCommands.go
@@ -1045,14 +1045,14 @@ type PrequeueTechCommand struct {
 }
 
 func (cmd PrequeueTechCommand) Refine(baseCommand *BaseCommand, data *[]byte) RawGameCommand {
-	// The prequeueTech command body is 16 bytes: 8 bytes of 0xff (a "no source"
-	// sentinel), 4 bytes of techId, and 4 trailing bytes (purpose unknown).
+	// Body: 8 bytes of 0xff (a "no source" sentinel), 4 bytes of techId, 4 trailing
+	// bytes (purpose unknown).
 	//
-	// Builds before 601511 used a 13-byte body (1 trailing flag byte instead of 4).
-	// We do not support those builds — replays from old patches will misalign here.
-	// The previous probe-and-detect was unreliable for replays that mix prequeueTech
-	// with selected-unit lists or non-trailing positions, and threading a build
-	// number through every command refiner isn't worth the complexity for one field.
+	// Patch history (see "Patch compatibility policy" in the project root CLAUDE.md
+	// for why we don't probe-and-detect):
+	//   2026-05-02: build 601511 changed the size from 13 to 16 (the trailing 1-byte
+	//               flag became a 4-byte field). Replays from older builds misalign
+	//               here — use a matching older release of this parser to read them.
 	byteLength := 16
 	enrichBaseCommand(baseCommand, byteLength)
 	techId := readInt32(data, baseCommand.offset+8)

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -1,0 +1,40 @@
+# tools/
+
+Ad-hoc Python probes used when AoM ships a patch and replays start failing to
+parse. **Not** shipped in the release binary, **not** required by the Go parser
+or the test pipeline. They exist so the next patch break can be diagnosed in
+seconds instead of rebuilt from scratch.
+
+## What's here
+
+| Script                       | Purpose |
+| ---------------------------- | ------- |
+| `decompress_inner.py`        | Strip the outer wrapper + l33t/zlib layer to produce the inner header bytes (`/tmp/inner_*.bin`). Use this when diff-walking the header tree, XMB name lists, or searching for moved UTF-16 strings (steps 3–7 of the patch-debugging playbook in `parser/CLAUDE.md`). |
+| `trace_command_stream.py`    | Walk every command list in the post-l33t command-stream region of a `.mythrec`, printing the offset, type, and body length of each command. Stops at the first parse failure with a precise diagnostic (which list, which command, which sentinel mismatched). This is the tool that pinpointed the prequeueTech mid-list misalignment in May 2026. |
+
+## How to run
+
+Each script has a [PEP 723](https://peps.python.org/pep-0723/) inline metadata
+header so `uv` resolves the (zero) dependencies and Python version automatically:
+
+```fish
+uv run tools/decompress_inner.py <replay.mythrec>
+uv run tools/trace_command_stream.py <replay.mythrec>
+uv run tools/trace_command_stream.py <replay.mythrec> --prequeue-tech-bytes 13
+```
+
+## Caveats
+
+These scripts mirror Go-parser logic (notably the per-command refiner byte
+lengths in `parser/gameCommands.go` and the command-list framing in
+`parser/gameCommandParser.go`). **They will drift.** When you add or change a
+refiner in Go, update the `REFINER_LENGTH` table in
+`trace_command_stream.py`. There are no tests guarding this; the contract is
+"matches the Go parser as of the last patch break." If the script disagrees with
+the Go parser on a known-good replay, the script is wrong.
+
+The patch-debugging playbook lives in the project root `CLAUDE.md` and the
+`parser/CLAUDE.md`. Read those before writing a new probe — most of the
+recipes you'll need (decompress once, walk the header tree, instrument
+`parseGameCommand`, probe-and-detect over hard-coding) are already documented
+there.

--- a/tools/decompress_inner.py
+++ b/tools/decompress_inner.py
@@ -1,0 +1,50 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Decompress the inner l33t/zlib layer of a .mythrec replay to raw bytes.
+
+Outputs to /tmp/inner_<basename>.bin by default, or to --out if specified.
+Useful for header-tree walking, XMB diffing, and UTF-16 string searches when
+a new AoM patch breaks parsing. See parser/CLAUDE.md for the playbook.
+
+Note: this is NOT the same as the byte stream the command-log walks against —
+the Go parser walks the OUTER (only-gzip-stripped) bytes for the command log,
+not this inner-decompressed buffer. Use this for header / XMB analysis only.
+"""
+
+import argparse
+import gzip
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+
+def decompress_l33t(data: bytes) -> bytes:
+    idx = data.find(b"l33t")
+    if idx < 0:
+        raise SystemExit("no l33t magic found")
+    # 4 bytes magic + 4 bytes uncompressed-size, then zlib stream
+    return zlib.decompress(data[idx + 8 :])
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("replay", type=Path, help="path to .mythrec or .mythrec.gz")
+    ap.add_argument("--gz", action="store_true", help="treat input as gzip")
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args()
+
+    raw = args.replay.read_bytes()
+    if args.gz or args.replay.suffix == ".gz":
+        raw = gzip.decompress(raw)
+
+    inner = decompress_l33t(raw)
+    out = args.out or Path("/tmp") / f"inner_{args.replay.stem}.bin"
+    out.write_bytes(inner)
+    print(f"wrote {len(inner):,} bytes ({len(inner):#x}) to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace_command_stream.py
+++ b/tools/trace_command_stream.py
@@ -1,0 +1,212 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Walk the command-log section of a .mythrec, printing per-list and per-command
+offsets, types, and body lengths. Stops at the first parse failure with a
+precise diagnostic.
+
+Mirrors the Go parser's command-stream walker
+(parser/gameCommandParser.go::parseCommandList + parseGameCommand) and the
+per-refiner byte lengths from parser/gameCommands.go. **Will drift** —
+re-sync REFINER_LENGTH when a refiner changes. See tools/CLAUDE.md.
+
+Usage:
+    uv run tools/trace_command_stream.py <replay.mythrec>
+    uv run tools/trace_command_stream.py <replay.mythrec> --quiet
+    uv run tools/trace_command_stream.py <replay.mythrec> --prequeue-tech-bytes 13
+
+The --prequeue-tech-bytes knob lets you A/B test alternate body lengths for
+command type 72 (prequeueTech) when a patch shifts its layout.
+"""
+
+import argparse
+import gzip
+import struct
+import sys
+from pathlib import Path
+
+# Refiner byte lengths, sourced from parser/gameCommands.go (Refine methods).
+# Re-check these against the source of truth when adding to it. Commands marked
+# "var" compute their length from a probe and need a special case below.
+REFINER_LENGTH = {
+    0: 44,    # task: 4 int32 + vector + float + 3 int32
+    1: 12,    # research: 3 int32
+    2: 18,    # train: 4 int32 + 2 int8
+    3: 52,    # build
+    4: 32,    # setGatherPoint: 2 int32 + vector + float + 2 int32
+    7: 9,    # delete: 2 int32 + int8
+    9: 8,    # stop: 2 int32
+    12: 57,   # useProtoPower
+    13: 20,   # marketBuySell
+    14: 8,    # ungarrison: 2 int32
+    16: 21,   # resign: 5 int32 + int8
+    18: 12,   # unknown 18: 3 int32
+    19: 25,   # tribute: 4 int32 + 2 float + int8
+    23: 18,   # finishUnitTransform: 4 int32 + 2 int8
+    25: 14,   # setUnitStance: 2 int32 + 2 int8 + int32
+    26: 13,   # changeDiplomacy: 2 int32 + int8 + int32
+    34: 8,    # townBell
+    35: 12,   # autoScoutEvent
+    37: 13,   # changeControlGroup: 2 int32 + int8 + int32
+    38: 12,   # repair: 3 int32
+    39: 12,   # unknown 39: 3 int32
+    41: 45,   # taunt
+    44: 16,   # cheat
+    45: 20,   # cancelQueuedItem: 5 int32
+    48: 16,   # setFormation
+    53: 12,   # startUnitTransform: 3 int32
+    55: 20,   # unknown 55: 2 int32 + vector
+    66: 12,   # autoqueue
+    67: 9,    # toggleAutoUnitAbility: 2 int32 + int8
+    68: 32,   # timeShift
+    69: 36,   # buildWallConnector: 3 int32 + 2 vector
+    71: 12,   # seekShelter: 3 int32
+    72: 16,   # prequeueTech (build >= 601511); --prequeue-tech-bytes overrides
+    73: 8,    # unknown 73: 2 int32
+    75: 16,   # prebuyGodPower
+    78: -1,   # unknown 78: 20 or 28 depending on probe (handled below)
+}
+
+
+def u16(d: bytes, o: int) -> int:
+    return struct.unpack_from("<H", d, o)[0]
+
+
+def u32(d: bytes, o: int) -> int:
+    return struct.unpack_from("<I", d, o)[0]
+
+
+def parse_game_command(data, offset, prequeue_bytes):
+    """Mirror parseGameCommand. Returns (next_offset, type, info, start)."""
+    start = offset
+    cmd_type = data[offset + 1]
+    ten = offset
+    offset += 10
+    offset += 20 if cmd_type == 14 else 8
+
+    three_off = offset
+    if u32(data, offset) != 3:
+        return None, cmd_type, f"three!=3 at 0x{three_off:x} (got {u32(data, three_off)})", start
+    offset += 4
+
+    if cmd_type == 19:
+        offset += 4
+    else:
+        if u16(data, offset) != 1:
+            return None, cmd_type, f"one!=1 at 0x{offset:x}", start
+        offset += 4
+        pid = u16(data, offset)
+        if pid > 12:
+            return None, cmd_type, f"playerId={pid}", start
+        offset += 4
+    offset += 4
+
+    nu = u16(data, offset); offset += 4 + 4 * nu
+    nv = u16(data, offset); offset += 4 + 12 * nv
+    npa = 13 + u16(data, offset); offset += 4 + npa
+
+    body_start = offset
+    if cmd_type == 78:
+        bl = 28 if u32(data, offset + 12) == 3 else 20
+    elif cmd_type == 72:
+        bl = prequeue_bytes
+    elif cmd_type in REFINER_LENGTH and REFINER_LENGTH[cmd_type] > 0:
+        bl = REFINER_LENGTH[cmd_type]
+    else:
+        return None, cmd_type, f"unregistered command type {cmd_type}", start
+
+    return offset + bl, cmd_type, f"body=0x{body_start:x}+{bl}", start
+
+
+def parse_command_list(data, offset, prequeue_bytes):
+    list_start = offset
+    et = u32(data, offset); offset += 5  # entryType + earlyByte
+    if et & 225 != et:
+        return None, f"bad entryType={et}", []
+    if et & 96 == 96:
+        return None, f"96 entryType={et}", []
+    offset += 1 if et & 1 else 4
+
+    log = [f"list@0x{list_start:x} et={et}"]
+    if et & 96 != 0:
+        if et & 32:
+            ni = data[offset]; offset += 1
+        else:
+            ni = u32(data, offset); offset += 4
+        for i in range(ni):
+            no, ct, info, cs = parse_game_command(data, offset, prequeue_bytes)
+            if no is None:
+                return None, f"cmd #{i+1} @0x{cs:x} type={ct}: {info}", log
+            log.append(f"  cmd#{i+1} @0x{cs:x} type={ct} -> 0x{no:x} ({info})")
+            offset = no
+
+    if et & 128:
+        ni = data[offset]; offset += 1 + 4 * ni
+
+    eb = data[offset]; offset += 1 + eb
+    unk = data[offset]; offset += 1
+    if unk == 0:
+        offset += 8
+    elif unk != 1:
+        return None, f"unk={unk}", log
+    f4 = u16(data, offset); offset += 4 + 4 * f4
+    eidx = u32(data, offset); offset += 4
+    fb = data[offset]
+    if fb != 0:
+        return None, f"finalByte={fb} at 0x{offset:x}", log
+    return offset + 1, None, log
+
+
+def find_command_stream_start(data: bytes, command_offset: int) -> int:
+    """Mirror parseGameCommands' header-end → footer search → -19 walkback."""
+    footer_idx = data.find(b"\x19\x00\x00\x00", command_offset)
+    if footer_idx < 0:
+        raise SystemExit("FOOTER not found after command_offset")
+    return footer_idx - 19
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("replay", type=Path)
+    ap.add_argument("--gz", action="store_true")
+    ap.add_argument("--quiet", action="store_true",
+                    help="only print first/last few lists and the failure")
+    ap.add_argument("--prequeue-tech-bytes", type=int, default=16,
+                    help="body length for command type 72 (default: 16)")
+    args = ap.parse_args()
+
+    raw = args.replay.read_bytes()
+    if args.gz or args.replay.suffix == ".gz":
+        raw = gzip.decompress(raw)
+
+    # commandCount = uint32 at offset 23 of the (gunzipped) outer file
+    command_count = u32(raw, 23)
+    sv_idx = raw.find(b"\x73\x76")
+    command_offset = u32(raw, sv_idx + 2)
+    start = find_command_stream_start(raw, command_offset)
+    print(f"commandCount={command_count} commandOffset=0x{command_offset:x} stream-start=0x{start:x}")
+
+    offset = start
+    n = 0
+    while offset < len(raw):
+        next_off, err, log = parse_command_list(raw, offset, args.prequeue_tech_bytes)
+        if err is not None:
+            print(f"\nFAIL at list #{n+1} (offset 0x{offset:x}): {err}")
+            for line in log:
+                print(line)
+            sys.exit(1)
+        if not args.quiet:
+            for line in log:
+                print(line)
+        offset = next_off
+        n += 1
+        if n >= command_count:
+            break
+
+    print(f"\nOK — parsed {n} command lists, ended at offset 0x{offset:x} "
+          f"(file size 0x{len(raw):x})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Hardcode `prequeueTech` body length to 16 bytes (build 601511+). Replaces the probe-and-detect added in #7, which silently fell back to 13 bytes when prequeueTech sat mid-list or in a list with `entryType & 128` selected-units, misaligning every subsequent command.
- Codify a patch-compatibility policy (`CLAUDE.md` + `README.md`): track the current AoM build only; hardcode sizes; annotate size changes with dated `Patch history:` comments; older replays parse with older releases.
- Add `tools/` with two reusable Python probes (`uv` PEP-723 inline metadata, no install): `decompress_inner.py` for header/XMB diffing, `trace_command_stream.py` for command-log bisection. Same approach the next patch break can lean on.
- Bump parser version to `v0.5.3`.

Reproducer: 6 build-601511 replays in `~/Downloads/broken_replays/` failed with cascading `expecting three=67108863`, `final byte != 0`, or `entryIdx not sequential` errors under the previous probe. All 6 now parse cleanly through their full `commandCount`; minor gods populated; 7-76 `prequeueTech` commands per replay.

## Test plan

- [x] `go fmt ./... && go vet ./...` clean
- [x] All 6 build-601511 replays in `~/Downloads/broken_replays/` exit 0 from `parse --slim -q`
- [x] Long 1v1 (`rm_mirage`) reports correct minor gods (Freyja / Heimdall) and 187 commands incl. 7 prequeueTech
- [x] `tools/trace_command_stream.py --prequeue-tech-bytes 13` correctly fails on a build-601511 replay (sanity-check that the tool mirrors the Go parser)
- [ ] Tag `v0.5.3` after merge to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)