### PR TITLE
fix: ignore phantom age-up techs that name a major god or civ

### DIFF
--- a/parser/consts.go
+++ b/parser/consts.go
@@ -3,7 +3,7 @@ package parser
 const MAX_SCAN_OFFSET = 50
 const DATA_OFFSET = 6
 const ROOT_NODE_TOKEN = "BG"
-const VERSION = "v0.5.3"
+const VERSION = "v0.5.4"
 
 var FOOTER = []uint8{0x19, 0x0, 0x0, 0x0}
 

--- a/parser/formatter.go
+++ b/parser/formatter.go
@@ -266,6 +266,33 @@ func playerExists(profileKeys *map[string]ProfileKey, playerNum int) bool {
 	return (*profileKeys)[playerKey].StringVal != ""
 }
 
+// nonMinorGodAgeUpSuffixes are tech-name suffixes that appear in the techtree as
+// "<Age>Age<Suffix>" but are NOT player-selectable minor gods: major god names
+// (e.g. MythicAgeIsis, HeroicAgeRa) and civilization tokens (ClassicalAgeAztec,
+// MythicAgeGeneral). These are template/placeholder entries the engine carries
+// alongside the real age-up techs.
+//
+// Why this matters: Aztec players' replays contain phantom prequeueTech commands
+// pointing at these placeholder techIds — most likely emitted by the age-up UI
+// when the player interacts with it. The phantoms have no in-game effect (the
+// player's actual choice is queued separately) but `getMinorGods` would record
+// the placeholder's suffix as the minor god, e.g. mistakenly reporting
+// "Isis"/"Ra" for an Aztec. Skipping these suffixes lets the real age-up tech
+// fill the slot.
+var nonMinorGodAgeUpSuffixes = map[string]struct{}{
+	// Major gods — never appear as a minor god of any civ.
+	"Zeus": {}, "Hades": {}, "Poseidon": {},
+	"Ra": {}, "Isis": {}, "Set": {},
+	"Thor": {}, "Odin": {}, "Loki": {}, "Freyr": {},
+	"Kronos": {}, "Oranos": {}, "Gaia": {}, "Demeter": {},
+	"Fuxi": {}, "Nuwa": {}, "Shennong": {},
+	"Amaterasu": {}, "Tsukuyomi": {}, "Susanoo": {},
+	"Huitzilopochtli": {}, "Tezcatlipoca": {}, "Quetzalcoatl": {},
+	// Civilization tokens / catch-alls — template entries only.
+	"Greek": {}, "Egyptian": {}, "Norse": {}, "Atlantean": {},
+	"Chinese": {}, "Japanese": {}, "Aztec": {}, "General": {},
+}
+
 func getMinorGods(playerNum int, commandList *[]RawGameCommand, techTreeRootNode *XmbNode) [3]string {
 	// Filter to all Research/prequeue techs that are Age Up tech,
 	ageUpTechs := []string{}
@@ -289,19 +316,32 @@ func getMinorGods(playerNum int, commandList *[]RawGameCommand, techTreeRootNode
 
 	slog.Debug("Age up techs", "playerNum", playerNum, "techs", ageUpTechs)
 
-	// Find the last occurrence of each age type and removes the prefix to make it look pretty
+	// Find the last occurrence of each age type and remove the prefix to make
+	// it look pretty. Skip any tech whose suffix is a major god or civ token
+	// (see nonMinorGodAgeUpSuffixes).
 	var classical, heroic, mythic string
 	for _, tech := range ageUpTechs {
 		if strings.HasPrefix(tech, "ClassicalAge") {
-			classical = strings.TrimPrefix(tech, "ClassicalAge")
+			if suffix := strings.TrimPrefix(tech, "ClassicalAge"); !isNonMinorGodSuffix(suffix) {
+				classical = suffix
+			}
 		} else if strings.HasPrefix(tech, "HeroicAge") {
-			heroic = strings.TrimPrefix(tech, "HeroicAge")
+			if suffix := strings.TrimPrefix(tech, "HeroicAge"); !isNonMinorGodSuffix(suffix) {
+				heroic = suffix
+			}
 		} else if strings.HasPrefix(tech, "MythicAge") {
-			mythic = strings.TrimPrefix(tech, "MythicAge")
+			if suffix := strings.TrimPrefix(tech, "MythicAge"); !isNonMinorGodSuffix(suffix) {
+				mythic = suffix
+			}
 		}
 	}
 
 	return [3]string{classical, heroic, mythic}
+}
+
+func isNonMinorGodSuffix(suffix string) bool {
+	_, ok := nonMinorGodAgeUpSuffixes[suffix]
+	return ok
 }
 
 func getEAPM(playerNum int, commandList *[]RawGameCommand, gameLengthSecs float64) float64 {


### PR DESCRIPTION
## Summary

- Aztec replays from AoM:R build 601891 were reporting incorrect minor gods — e.g. `MinorGods: [\"Malinalxochitl\", \"Itzpapalotl\", \"Isis\"]` for an Aztec player, or a `\"Ra\"` slot in a Tezcatlipoca player's Heroic age.
- Root cause: the replays themselves contain phantom `prequeueTech` commands targeting *Egyptian-template* techs (techIds 98, 100, 105 → `ArchaicAgeRa`, `HeroicAgeRa`, `MythicAgeIsis`) that the game emits when an Aztec player interacts with the age-up UI. The parser correctly resolves the techIds; the bug is that `getMinorGods`' last-write-wins loop accepts these placeholder suffixes as minor god names.
- Fix: a small denylist of major god names (Zeus, Hades, Poseidon, Ra, Isis, Set, Thor, Odin, Loki, Freyr, Kronos, Oranos, Gaia, Demeter, Fuxi, Nuwa, Shennong, Amaterasu, Tsukuyomi, Susanoo, Huitzilopochtli, Tezcatlipoca, Quetzalcoatl) and civ tokens (Greek, Egyptian, Norse, Atlantean, Chinese, Japanese, Aztec, General). After stripping the `<Age>Age` prefix, any tech whose suffix is in the denylist is skipped — letting a real age-up tech keep the slot, or leaving it empty when no real age-up happened.
- Bumps `parser.VERSION` from v0.5.3 → v0.5.4.

## Why a denylist (and not a per-civ allowlist)

Major god names and civ tokens are *never* legal minor god names for any civilization. That's the only invariant the fix needs, and it doesn't require threading civ → minor-gods tables through the parser. A per-civ allowlist would also work but would need to be maintained whenever a new minor god ships.

## Verification

Verified on two AoM:R build 601891 replays containing four players (one Greek/Zeus, three Aztec). Before/after `MinorGods`:

| Player | Civ / Major | Before | After |
| --- | --- | --- | --- |
| Don | Greek / Zeus | Athena · Dionysus · _empty_ | Athena · Dionysus · _empty_ ✓ |
| DOMINVS | Aztec / Huitzilopochtli | Malinalxochitl · Itzpapalotl · **Isis** | Malinalxochitl · Itzpapalotl · _empty_ ✓ (he never reached Mythic) |
| DjéLaKé | Aztec / Huitzilopochtli | Patecatl · Itzpapalotl · _empty_ | Patecatl · Itzpapalotl · _empty_ ✓ |
| esba_snake | Aztec / Tezcatlipoca | Malinalxochitl · **Ra** · Xolotl | Malinalxochitl · Itzpapalotl · Xolotl ✓ |

Each \"correct\" answer above was cross-checked against the player's own `prequeueTech`/`research` command stream — the fix promotes the real player choice into the slot rather than the engine-emitted placeholder.

## Test plan

- [x] `go fmt ./... && go vet ./... && go build`
- [x] Reparse both Aztec replays; confirm minor gods match the players' actual age-up commands
- [x] Reparse the Greek player in replay 1; confirm output unchanged
- [ ] (Manual) Reparse a known-good pre-Aztec replay and confirm output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)